### PR TITLE
Add Possibility of custom end string

### DIFF
--- a/src/components/read-more-web.tsx
+++ b/src/components/read-more-web.tsx
@@ -1,5 +1,6 @@
+import type { CSSProperties } from 'react';
+import React from 'react';
 import { ReadMore } from './read-more';
-import React, { CSSProperties } from 'react';
 
 export interface ReadMoreWebProps {
 	truncate: number | undefined;
@@ -8,6 +9,7 @@ export interface ReadMoreWebProps {
 	className?: string;
 	style?: CSSProperties;
 	children: React.ReactNode;
+	endTruncate?: string;
 }
 
 export const ReadMoreWeb: React.FC<ReadMoreWebProps> = ({
@@ -17,6 +19,7 @@ export const ReadMoreWeb: React.FC<ReadMoreWebProps> = ({
 	className,
 	style,
 	children,
+	endTruncate,
 }) => {
 	const [expanded, setExpanded] = React.useState(false);
 
@@ -27,6 +30,7 @@ export const ReadMoreWeb: React.FC<ReadMoreWebProps> = ({
 	return (
 		<ReadMore
 			truncate={truncate}
+			endTruncate={endTruncate}
 			expanded={expanded}
 			showMore={
 				<>


### PR DESCRIPTION
I'm trying to use the lib with custom children.

The problem is that I don't know if the component will receive content that starts with an HTML tag or not.

Example, I might receive this:
```
<p>Lorem ipsum dolor sit amet, <a href="http://localhost:3000" class="link">consectetur adipiscing elit. Sed ullamcorper, odio eu aliquam ultricies, enim sapien aliquet arcu, quis aliquam diam massa eu nisl. Sed vitae nunc eget nunc ullamcorper aliquet.</a> Sed euismod, nisl eget aliquam ultricies, justo nisl aliquet nunc, quis aliquam diam massa eu nisl. Sed vitae nunc eget nunc ullamcorper aliquet.</p>
```

The way that today is, will render this:
![image](https://github.com/lucasbasquerotto/react-read-more/assets/2483403/7073f81d-b219-42ca-bea3-4e936fca63da)

But I think it's better to show it like this:
![image](https://github.com/lucasbasquerotto/react-read-more/assets/2483403/71a58993-3c7f-4ffe-819a-8b4736e97e4c)

So I think it could be adding new prop to receive this string.